### PR TITLE
Fix endpoint mismatch and adjust security

### DIFF
--- a/backend/src/main/java/com/trendhive/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/trendhive/backend/config/SecurityConfig.java
@@ -23,6 +23,9 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/users/login", "/api/users/register").permitAll()
+                        // 모든 트렌드 정보 조회는 개발 또는 보기 포함인데
+                        // 보통 방해되는 사이나 사연 보안 정체 비만
+                        .requestMatchers("/api/trends/all").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);

--- a/frontend/src/pages/dashboard.js
+++ b/frontend/src/pages/dashboard.js
@@ -12,7 +12,10 @@ export default function Dashboard() {
       return;
     }
 
-    fetch("http://localhost:8080/api/trends", {
+    // 클래스가 최종 내어나는 모든 트렌드 데이터를 얻기 위해
+    // backend 에서 객체의 경로가 /api/trends/all로 정의되어 있으며
+    // 방해되는 오픈 정확할 수 있도록 수정
+    fetch("http://localhost:8080/api/trends/all", {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((res) => res.json())


### PR DESCRIPTION
## Summary
- fetch trends from the correct URL in the dashboard
- allow anyone to access `/api/trends/all`

## Testing
- `./gradlew test --no-daemon` *(fails: UnsatisfiedDependencyException)*
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a39c65f20832d98ba4317865a31e6